### PR TITLE
Add orchestrated loan risk assistant scaffolding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,2 +1,28 @@
 # Risk-Assessment-Prototype-1
-Round one of creating a watsonx powered AI solution that weighs risk assessment for borrowers and lenders
+
+Prototype scaffolding for a watsonx-powered loan risk assessment agent. The
+package `loan_risk_assistant` coordinates policy retrieval, risk scoring, and
+compliance logging into a single `LoanRiskAssistant` class. The class expects
+callables for the bank's existing tooling (policy retrieval, risk scoring API,
+policy lookup, governance logging, etc.) and returns the structured JSON format
+required by the business specification.
+
+## Layout
+
+- `loan_risk_assistant/` – Core package with data models and orchestration
+  logic.
+- `examples/sample_run.py` – Demonstrates wiring the assistant with stubbed
+  tools.
+- `tests/` – Pytest coverage for the orchestration behaviour.
+
+## Running the sample
+
+```bash
+python examples/sample_run.py
+```
+
+## Running tests
+
+```bash
+pytest
+```

--- a/examples/sample_run.py
+++ b/examples/sample_run.py
@@ -1,0 +1,131 @@
+"""Example execution of the LoanRiskAssistant with stubbed tools."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Dict, List
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from loan_risk_assistant import (
+    GovernanceLogRecord,
+    InterestBand,
+    LoanApplication,
+    LoanRiskAssistant,
+    PolicyChunk,
+    ReasonCode,
+    RiskFeature,
+    RiskScoreResult,
+)
+
+
+def _policy_retriever(query: str, top_k: int = 5) -> List[PolicyChunk]:
+    metadata = {
+        "guidance": "Tier-based interest premium",
+        "interest_band": {
+            "min_apr": 7.25,
+            "max_apr": 9.5,
+            "policy_reference": "POL-INT-2024-1",
+            "conditions": ["Auto-pay enrollment"],
+        },
+        "required_documents": [
+            "Signed personal financial statement",
+        ],
+    }
+    return [
+        PolicyChunk(
+            chunk_id="chunk-001",
+            title="SMB Term Lending Manual",
+            section="4.2",
+            text="For high-risk SMB borrowers, apply a premium between 7.25% and 9.5% APR contingent on auto-pay enrollment.",
+            metadata=metadata,
+        )
+    ]
+
+
+def _risk_scoring_api(payload: Dict[str, object]) -> RiskScoreResult:
+    features = [
+        RiskFeature(
+            code="CREDIT_SCORE",
+            description="Credit score below 680",
+            value=payload["borrower"].get("credit_score", 0),
+            direction="increase",
+            weight=0.27,
+        ),
+        RiskFeature(
+            code="DTI_RATIO",
+            description="Debt-to-income ratio above 40%",
+            value=payload["borrower"].get("dti", 0.0),
+            direction="increase",
+            weight=0.19,
+        ),
+    ]
+    reason_codes = [
+        ReasonCode(code="CREDIT_SCORE", description="Credit score below tier threshold"),
+        ReasonCode(code="DTI_RATIO", description="Elevated debt-to-income ratio"),
+    ]
+    return RiskScoreResult(score=72.0, features=features, reason_codes=reason_codes)
+
+
+def _get_policy_by_id(ids: List[str]) -> Dict[str, PolicyChunk]:
+    chunks = _policy_retriever("", top_k=len(ids))
+    return {chunk.chunk_id: chunk for chunk in chunks if chunk.chunk_id in ids}
+
+
+def _compose_user_packet(data: Dict[str, object]) -> Dict[str, object]:
+    html = "<h1>Loan Assessment</h1>"
+    html += f"<p>Risk Score: {data['risk_score']['value']} ({data['risk_score']['tier']})</p>"
+    html += "<ul>" + "".join(
+        f"<li>{reason['label']}: {reason['detail']}</li>" for reason in data["reasons"]
+    ) + "</ul>"
+    return {"format": "html", "content": html}
+
+
+def _request_additional_docs(documents: List[str]) -> Dict[str, object]:
+    return {"requested": documents}
+
+
+class _GovernanceLogger:
+    def __init__(self) -> None:
+        self._counter = 0
+
+    def __call__(self, event_type: str, payload: Dict[str, object]) -> GovernanceLogRecord:
+        self._counter += 1
+        return GovernanceLogRecord(event_type=event_type, log_id=f"log-{self._counter}")
+
+
+def main() -> None:
+    assistant = LoanRiskAssistant(
+        policy_docs_retriever=_policy_retriever,
+        risk_scoring_api=_risk_scoring_api,
+        get_policy_by_id=_get_policy_by_id,
+        compose_user_packet=_compose_user_packet,
+        request_additional_docs=_request_additional_docs,
+        governance_log=_GovernanceLogger(),
+    )
+
+    application = LoanApplication(
+        application_id="APP-123",
+        borrower={
+            "credit_score": 645,
+            "dti": 0.46,
+            "employment_type": "self_employed",
+            "income_verified": False,
+        },
+        loan={
+            "amount": 250000,
+            "term_months": 60,
+            "collateral_required": True,
+        },
+        region="CA",
+        product="smb_term",
+    )
+
+    response = assistant.assess(application)
+    print(response)
+
+
+if __name__ == "__main__":
+    main()

--- a/loan_risk_assistant/__init__.py
+++ b/loan_risk_assistant/__init__.py
@@ -1,0 +1,23 @@
+"""Loan Risk Assistant package."""
+
+from .agent import LoanRiskAssistant
+from .models import (
+    GovernanceLogRecord,
+    InterestBand,
+    LoanApplication,
+    PolicyChunk,
+    RiskFeature,
+    ReasonCode,
+    RiskScoreResult,
+)
+
+__all__ = [
+    "LoanRiskAssistant",
+    "GovernanceLogRecord",
+    "InterestBand",
+    "LoanApplication",
+    "PolicyChunk",
+    "RiskFeature",
+    "ReasonCode",
+    "RiskScoreResult",
+]

--- a/loan_risk_assistant/agent.py
+++ b/loan_risk_assistant/agent.py
@@ -1,0 +1,295 @@
+"""Core orchestration logic for the Loan Risk Assistant."""
+from __future__ import annotations
+
+from dataclasses import asdict
+from typing import Any, Dict, List, Optional
+
+from .models import (
+    GovernanceLogRecord,
+    InterestBand,
+    LoanApplication,
+    PolicyChunk,
+    RiskFeature,
+    RiskScoreResult,
+)
+from .tools import (
+    ComposeUserPacket,
+    GetPolicyById,
+    GovernanceLog,
+    InterestPolicyResolver,
+    PolicyDocsRetriever,
+    RequestAdditionalDocs,
+    RiskScoringAPI,
+)
+
+
+class LoanRiskAssistant:
+    """Coordinates the risk assessment workflow across all tools."""
+
+    def __init__(
+        self,
+        *,
+        policy_docs_retriever: PolicyDocsRetriever,
+        risk_scoring_api: RiskScoringAPI,
+        get_policy_by_id: GetPolicyById,
+        compose_user_packet: ComposeUserPacket,
+        request_additional_docs: RequestAdditionalDocs,
+        governance_log: GovernanceLog,
+        interest_policy_resolver: Optional[InterestPolicyResolver] = None,
+        policy_top_k: int = 5,
+    ) -> None:
+        self.policy_docs_retriever = policy_docs_retriever
+        self.risk_scoring_api = risk_scoring_api
+        self.get_policy_by_id = get_policy_by_id
+        self.compose_user_packet = compose_user_packet
+        self.request_additional_docs = request_additional_docs
+        self.governance_log = governance_log
+        self.interest_policy_resolver = interest_policy_resolver
+        self.policy_top_k = policy_top_k
+
+    def assess(self, application: LoanApplication) -> Dict[str, Any]:
+        """Run the end-to-end assessment for a single application."""
+
+        governance_ids: List[str] = []
+        governance_ids.append(
+            self._log(
+                "problem_received",
+                {
+                    "application_id": application.application_id,
+                    "region": application.region,
+                    "product": application.product,
+                    "redactions": True,
+                },
+            ).log_id
+        )
+
+        query = self._build_policy_query(application)
+        policy_chunks = self.policy_docs_retriever(query, top_k=self.policy_top_k)
+        governance_ids.append(
+            self._log(
+                "retrieval_done",
+                {
+                    "application_id": application.application_id,
+                    "query": query,
+                    "chunk_ids": [chunk.chunk_id for chunk in policy_chunks],
+                },
+            ).log_id
+        )
+
+        risk_payload = self._build_risk_payload(application)
+        risk_result = self.risk_scoring_api(risk_payload)
+        governance_ids.append(
+            self._log(
+                "risk_scored",
+                {
+                    "application_id": application.application_id,
+                    "risk_score": risk_result.score,
+                    "reason_codes": [code.code for code in risk_result.reason_codes],
+                },
+            ).log_id
+        )
+
+        resolved_policies = self._resolve_policy_chunks(policy_chunks)
+        policy_citations = self._build_policy_citations(resolved_policies)
+
+        risk_tier = self._tier_from_score(risk_result.score)
+        reasons = self._build_reasons(risk_result, resolved_policies)
+
+        requested_documents = self._determine_requested_documents(application, risk_result, resolved_policies)
+        if requested_documents:
+            self.request_additional_docs(requested_documents)
+
+        interest_band = self._determine_interest_band(risk_tier, resolved_policies)
+        policy_gap = interest_band is None
+
+        user_packet_payload = {
+            "application_id": application.application_id,
+            "risk_score": {
+                "value": risk_result.score,
+                "tier": risk_tier,
+            },
+            "reasons": reasons,
+            "requested_documents": requested_documents,
+            "policy_citations": policy_citations,
+            "interest_band": asdict(interest_band) if interest_band else None,
+        }
+        user_packet = self.compose_user_packet(user_packet_payload)
+        governance_ids.append(
+            self._log(
+                "packet_composed",
+                {
+                    "application_id": application.application_id,
+                    "payload_keys": list(user_packet_payload.keys()),
+                },
+            ).log_id
+        )
+
+        response: Dict[str, Any] = {
+            "application_id": application.application_id,
+            "risk_score": {
+                "value": risk_result.score,
+                "scale": "0-100",
+                "tier": risk_tier,
+            },
+            "reasons": reasons,
+            "policy_citations": policy_citations,
+            "requested_documents": requested_documents,
+            "interest_rate_suggestion": (
+                {
+                    "band_apr_percent": [
+                        round(interest_band.min_apr, 2),
+                        round(interest_band.max_apr, 2),
+                    ],
+                    "basis": interest_band.policy_reference,
+                    "conditions": interest_band.conditions,
+                }
+                if interest_band
+                else None
+            ),
+            "compliance": {
+                "region": application.region,
+                "product": application.product,
+                "policy_gap": policy_gap,
+            },
+            "governance_log_ids": governance_ids,
+            "user_packet": user_packet,
+        }
+
+        return response
+
+    # ---------------------------------------------------------------------
+    # Helper methods
+    # ---------------------------------------------------------------------
+    def _log(self, event_type: str, payload: Dict[str, Any]) -> GovernanceLogRecord:
+        return self.governance_log(event_type, payload)
+
+    def _build_policy_query(self, application: LoanApplication) -> str:
+        context_terms = []
+        if application.context:
+            for key, value in application.context.items():
+                context_terms.append(f"{key}:{value}")
+        base_terms = [application.region, application.product, "risk tiering", "interest band", "documentation"]
+        return " ".join(term for term in base_terms + context_terms if term)
+
+    def _build_risk_payload(self, application: LoanApplication) -> Dict[str, Any]:
+        payload: Dict[str, Any] = {
+            "application_id": application.application_id,
+            "borrower": application.borrower,
+            "loan": application.loan,
+            "region": application.region,
+            "product": application.product,
+        }
+        if application.context:
+            payload["context"] = application.context
+        return payload
+
+    def _resolve_policy_chunks(self, policy_chunks: List[PolicyChunk]) -> List[PolicyChunk]:
+        if not policy_chunks:
+            return []
+        resolved = self.get_policy_by_id([chunk.chunk_id for chunk in policy_chunks])
+        output: List[PolicyChunk] = []
+        for chunk in policy_chunks:
+            output.append(resolved.get(chunk.chunk_id, chunk))
+        return output
+
+    def _build_policy_citations(self, policy_chunks: List[PolicyChunk]) -> List[Dict[str, Any]]:
+        citations: List[Dict[str, Any]] = []
+        for chunk in policy_chunks[:5]:  # limit to reduce noise
+            citations.append(
+                {
+                    "chunk_id": chunk.chunk_id,
+                    "title": chunk.title,
+                    "section": chunk.section,
+                    "quote": chunk.quote(),
+                }
+            )
+        return citations
+
+    def _tier_from_score(self, score: float) -> str:
+        if score < 34:
+            return "Low"
+        if score < 67:
+            return "Med"
+        return "High"
+
+    def _build_reasons(self, risk_result: RiskScoreResult, policy_chunks: List[PolicyChunk]) -> List[Dict[str, Any]]:
+        reasons: List[Dict[str, Any]] = []
+
+        feature_lookup: Dict[str, RiskFeature] = {feature.code: feature for feature in risk_result.features}
+        for reason in risk_result.reason_codes:
+            feature = feature_lookup.get(reason.code)
+            detail = reason.description
+            if feature:
+                direction = "raised" if feature.direction.lower() == "increase" else "reduced"
+                detail = (
+                    f"{reason.description} — feature value {feature.value!r} {direction} risk"
+                )
+            reasons.append(
+                {
+                    "label": reason.description,
+                    "detail": detail,
+                    "source": {"type": "feature", "id_or_code": reason.code},
+                }
+            )
+
+        for chunk in policy_chunks:
+            if "guidance" in chunk.metadata:
+                reasons.append(
+                    {
+                        "label": chunk.metadata.get("guidance", "Policy guidance"),
+                        "detail": chunk.quote(),
+                        "source": {"type": "policy", "id_or_code": chunk.chunk_id},
+                    }
+                )
+        return reasons[:8]
+
+    def _determine_requested_documents(
+        self,
+        application: LoanApplication,
+        risk_result: RiskScoreResult,
+        policy_chunks: List[PolicyChunk],
+    ) -> List[str]:
+        documents = set()
+
+        borrower = application.borrower
+        employment_type = borrower.get("employment_type")
+        if employment_type == "self_employed":
+            documents.add("Most recent 2 years of tax returns")
+        if not borrower.get("income_verified", False):
+            documents.add("Recent income verification (e.g., pay stubs or bank statements)")
+
+        if application.loan.get("collateral_required") and not application.loan.get("collateral_documents"):
+            documents.add("Collateral ownership evidence")
+
+        for code in risk_result.reason_codes:
+            if code.code.upper().startswith("DTI"):
+                documents.add("Detailed debt obligation schedule")
+            if code.code.upper().startswith("CREDIT"):
+                documents.add("Updated credit bureau report")
+
+        for chunk in policy_chunks:
+            for document in chunk.metadata.get("required_documents", []):
+                documents.add(document)
+
+        return sorted(documents)
+
+    def _determine_interest_band(
+        self, risk_tier: str, policy_chunks: List[PolicyChunk]
+    ) -> Optional[InterestBand]:
+        if self.interest_policy_resolver:
+            band = self.interest_policy_resolver(policy_chunks, risk_tier)
+            if band:
+                return band
+
+        for chunk in policy_chunks:
+            band_data = chunk.metadata.get("interest_band")
+            if not band_data:
+                continue
+            min_apr = band_data.get("min_apr")
+            max_apr = band_data.get("max_apr")
+            if min_apr is None or max_apr is None:
+                continue
+            reference = band_data.get("policy_reference", chunk.chunk_id)
+            conditions = band_data.get("conditions", [])
+            return InterestBand(min_apr=min_apr, max_apr=max_apr, policy_reference=reference, conditions=conditions)
+        return None

--- a/loan_risk_assistant/models.py
+++ b/loan_risk_assistant/models.py
@@ -1,0 +1,82 @@
+"""Data models supporting the loan risk assistant orchestration."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+
+@dataclass
+class PolicyChunk:
+    """Represents a retrieved policy chunk."""
+
+    chunk_id: str
+    title: str
+    section: str
+    text: str
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+    def quote(self, word_limit: int = 50) -> str:
+        """Return a truncated quote respecting the <=50 words requirement."""
+        words = self.text.split()
+        if len(words) <= word_limit:
+            return self.text
+        return " ".join(words[:word_limit])
+
+
+@dataclass
+class RiskFeature:
+    """Feature contribution returned by the risk scoring API."""
+
+    code: str
+    description: str
+    value: Any
+    direction: str  # e.g. "increase" or "decrease"
+    weight: float
+
+
+@dataclass
+class ReasonCode:
+    """Structured reason code returned by the risk scoring API."""
+
+    code: str
+    description: str
+
+
+@dataclass
+class RiskScoreResult:
+    """Standardised output from the risk scoring API."""
+
+    score: float
+    features: List[RiskFeature]
+    reason_codes: List[ReasonCode]
+
+
+@dataclass
+class LoanApplication:
+    """Minimal loan application payload passed to the assistant."""
+
+    application_id: str
+    borrower: Dict[str, Any]
+    loan: Dict[str, Any]
+    region: str
+    product: str
+    context: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class GovernanceLogRecord:
+    """Governance log response wrapper."""
+
+    event_type: str
+    log_id: str
+    payload_hash: Optional[str] = None
+
+
+@dataclass
+class InterestBand:
+    """Represents a policy backed interest band suggestion."""
+
+    min_apr: float
+    max_apr: float
+    policy_reference: str
+    conditions: List[str] = field(default_factory=list)

--- a/loan_risk_assistant/tools.py
+++ b/loan_risk_assistant/tools.py
@@ -1,0 +1,43 @@
+"""Protocol definitions for the external tools used by the assistant."""
+from __future__ import annotations
+
+from typing import Any, Dict, Iterable, List, Protocol
+
+from .models import GovernanceLogRecord, InterestBand, PolicyChunk, RiskScoreResult
+
+
+class PolicyDocsRetriever(Protocol):
+    def __call__(self, query: str, top_k: int = 5) -> List[PolicyChunk]:
+        ...
+
+
+class RiskScoringAPI(Protocol):
+    def __call__(self, payload: Dict[str, Any]) -> RiskScoreResult:
+        ...
+
+
+class GetPolicyById(Protocol):
+    def __call__(self, ids: Iterable[str]) -> Dict[str, PolicyChunk]:
+        ...
+
+
+class ComposeUserPacket(Protocol):
+    def __call__(self, data: Dict[str, Any]) -> Dict[str, Any]:
+        ...
+
+
+class RequestAdditionalDocs(Protocol):
+    def __call__(self, documents: List[str]) -> Dict[str, Any]:
+        ...
+
+
+class GovernanceLog(Protocol):
+    def __call__(self, event_type: str, payload: Dict[str, Any]) -> GovernanceLogRecord:
+        ...
+
+
+class InterestPolicyResolver(Protocol):
+    """Optional helper that computes interest bands from policy metadata."""
+
+    def __call__(self, policy_chunks: List[PolicyChunk], risk_tier: str) -> InterestBand | None:
+        ...

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+from typing import Dict, List
+
+import pytest
+
+from loan_risk_assistant import (
+    GovernanceLogRecord,
+    LoanApplication,
+    LoanRiskAssistant,
+    PolicyChunk,
+    ReasonCode,
+    RiskFeature,
+    RiskScoreResult,
+)
+
+
+@pytest.fixture()
+def assistant() -> LoanRiskAssistant:
+    def _policy_retriever(query: str, top_k: int = 5) -> List[PolicyChunk]:
+        metadata = {
+            "guidance": "Documented collateral required",
+            "interest_band": {
+                "min_apr": 6.0,
+                "max_apr": 8.5,
+                "policy_reference": "POL-APR-01",
+                "conditions": ["Manual review"],
+            },
+            "required_documents": ["Collateral appraisal report"],
+        }
+        return [
+            PolicyChunk(
+                chunk_id="chunk-xyz",
+                title="SMB Lending Policy",
+                section="3.1",
+                text="Loans flagged as medium risk must document collateral and may carry 6%-8.5% APR.",
+                metadata=metadata,
+            )
+        ]
+
+    def _risk_scoring_api(payload: Dict[str, object]) -> RiskScoreResult:
+        features = [
+            RiskFeature(
+                code="CREDIT_SCORE",
+                description="Credit score below internal target",
+                value=payload["borrower"].get("credit_score", 0),
+                direction="increase",
+                weight=0.21,
+            )
+        ]
+        reason_codes = [
+            ReasonCode(code="CREDIT_SCORE", description="Credit score below target"),
+        ]
+        return RiskScoreResult(score=55.0, features=features, reason_codes=reason_codes)
+
+    def _get_policy_by_id(ids: List[str]) -> Dict[str, PolicyChunk]:
+        chunks = _policy_retriever("", top_k=len(ids))
+        return {chunk.chunk_id: chunk for chunk in chunks if chunk.chunk_id in ids}
+
+    def _compose_user_packet(data: Dict[str, object]) -> Dict[str, object]:
+        return {"format": "html", "content": "ok"}
+
+    def _request_additional_docs(documents: List[str]) -> Dict[str, object]:
+        return {"requested": documents}
+
+    class _GovernanceLogger:
+        def __init__(self) -> None:
+            self.counter = 0
+
+        def __call__(self, event_type: str, payload: Dict[str, object]) -> GovernanceLogRecord:
+            self.counter += 1
+            return GovernanceLogRecord(event_type=event_type, log_id=f"log-{self.counter}")
+
+    return LoanRiskAssistant(
+        policy_docs_retriever=_policy_retriever,
+        risk_scoring_api=_risk_scoring_api,
+        get_policy_by_id=_get_policy_by_id,
+        compose_user_packet=_compose_user_packet,
+        request_additional_docs=_request_additional_docs,
+        governance_log=_GovernanceLogger(),
+    )
+
+
+def test_assistant_returns_structured_payload(assistant: LoanRiskAssistant) -> None:
+    application = LoanApplication(
+        application_id="APP-001",
+        borrower={"credit_score": 610, "income_verified": False},
+        loan={"collateral_required": True},
+        region="NY",
+        product="smb_term",
+    )
+
+    response = assistant.assess(application)
+
+    assert response["risk_score"]["value"] == pytest.approx(55.0)
+    assert response["risk_score"]["tier"] == "Med"
+    assert response["interest_rate_suggestion"]["band_apr_percent"] == [6.0, 8.5]
+    assert "Collateral ownership evidence" in response["requested_documents"]
+    assert response["governance_log_ids"]
+    assert response["user_packet"]["format"] == "html"


### PR DESCRIPTION
## Summary
- add a configurable `LoanRiskAssistant` orchestrator that coordinates governance logging, policy retrieval, risk scoring, document requests, and response synthesis
- define supporting data models, tool protocols, and provide a runnable sample script plus pytest coverage
- document the repository layout and basic usage in the README

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e2942df2a88322af628e968b68990d