### PR TITLE
Add governance logging for additional document requests

### DIFF
--- a/examples/sample_run.py
+++ b/examples/sample_run.py
@@ -84,7 +84,7 @@ def _compose_user_packet(data: Dict[str, object]) -> Dict[str, object]:
 
 
 def _request_additional_docs(documents: List[str]) -> Dict[str, object]:
-    return {"requested": documents}
+    return {"requested": documents, "request_id": "doc-req-1"}
 
 
 class _GovernanceLogger:

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -61,7 +61,7 @@ def assistant() -> LoanRiskAssistant:
         return {"format": "html", "content": "ok"}
 
     def _request_additional_docs(documents: List[str]) -> Dict[str, object]:
-        return {"requested": documents}
+        return {"requested": documents, "request_id": "doc-req-1"}
 
     class _GovernanceLogger:
         def __init__(self) -> None:


### PR DESCRIPTION
## Summary
- wrap additional-document requests in governance logging and capture response identifiers for traceability
- extend sample and test request stubs with deterministic request identifiers to exercise the new logging path

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e2981f5a0883229b0aa550e2a19b4c